### PR TITLE
Document env-based configuration flow and add .env example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Local environment & variables
 .env
+!config/.env
 .venv/
 
 # JetBrains IDE folder

--- a/README.md
+++ b/README.md
@@ -29,11 +29,18 @@ Clinical Trial Protocol Chatbot (MVP): query trial eligibility criteria, outcome
 ```bash
 python3 -m venv .venv && source .venv/bin/activate
 pip install -r requirements.txt
+cp config/.env.example config/.env
+# Edit config/.env with provider keys / endpoints
 cp config/appsettings.example.toml config/appsettings.toml
-# Edit config/appsettings.toml with your keys / endpoints
+# Optional: adjust config/appsettings.toml for non-secret defaults
 make seed # downloads trials from ClinicalTrials.gov and indexes them
 make run
 ```
+
+TrialWhisperer loads environment variables from `config/.env` (or a `.env` file
+in the repository root). Secrets such as LLM and Qdrant credentials should live
+there. `config/appsettings.toml` is optional and supplies non-secret fallback
+defaults when an environment variable is unset.
 
 The seeding step requires an accessible Qdrant instance. If `QDRANT_URL` and
 `QDRANT_API_KEY` are not set, the script will attempt to start a local Qdrant
@@ -229,26 +236,27 @@ vector index reflects the freshly downloaded trials.
 
 ```bash
 docker build -t trial-whisperer .
-# assumes config/appsettings.toml exists locally
+# ensure config/.env exists locally
 docker run --rm -p 8000:8000 \
-  -v $(pwd)/config/appsettings.toml:/app/config/appsettings.toml:ro \
+  --env-file config/.env \
   trial-whisperer
 ```
 
-This mounts your local `config/appsettings.toml` into the container, making it
-the single source of configuration. Alternatively, copy the file into the
-image at build time if you prefer.
+Mount or bake in `config/appsettings.toml` only when you need additional
+non-secret defaults inside the container. The environment variables in
+`config/.env` remain the primary configuration surface.
 
 The container exposes the FastAPI app on port 8000 by default.
 
 ### Environment variables
 
-Environment variables are optional and override values in
-`config/appsettings.toml`. For example:
+Environment variables drive most configuration, whether exported directly or
+loaded from `config/.env`. Override values in the env file at run time if
+needed:
 
 ```bash
 docker run --rm -p 8000:8000 \
-  -v $(pwd)/config/appsettings.toml:/app/config/appsettings.toml:ro \
+  --env-file config/.env \
   -e LLM_API_KEY="override" \
   trial-whisperer
 ```
@@ -256,6 +264,7 @@ docker run --rm -p 8000:8000 \
 - `LLM_API_KEY` – API key for your LLM provider.
 - `QDRANT_URL` – Qdrant cloud endpoint (including port number e.g. `https://YOUR.QDRANT.URL:6333`).
 - `QDRANT_API_KEY` – Qdrant authentication token.
+- `QDRANT_COLLECTION` – Vector collection name for seeded trials.
 - `TRIALS_DATA_PATH` – Location of the processed trials JSONL file. Override to
   switch between seeded data and ad-hoc datasets (defaults to
   `.data/processed/trials.jsonl`).

--- a/app/deps.py
+++ b/app/deps.py
@@ -18,7 +18,7 @@ class Settings(BaseSettings):
 
     model_config = SettingsConfigDict(
         extra="ignore",
-        env_file=".env",
+        env_file=("config/.env", ".env"),
         env_file_encoding="utf-8",
     )
 

--- a/config/.env.example
+++ b/config/.env.example
@@ -1,0 +1,28 @@
+# Environment variables consumed by TrialWhisperer.
+#
+# Copy this file to config/.env and fill in provider credentials and endpoints.
+# Values here are safe defaults; secrets must be supplied per deployment.
+
+# --- LLM configuration ---
+LLM_PROVIDER=gemini
+LLM_MODEL=gemini-2.5-flash
+# Insert your API key for the selected provider.
+LLM_API_KEY=
+
+# --- Retrieval backend ---
+RETRIEVAL_BACKEND=qdrant
+# Qdrant endpoint; keep http://localhost:6333 for Docker Compose/local stacks.
+QDRANT_URL=http://localhost:6333
+# Provide the Qdrant API key when targeting a managed instance.
+QDRANT_API_KEY=
+# Collection name used for seeded vectors.
+QDRANT_COLLECTION=trialwhisperer
+
+# --- Data paths ---
+# Location of the processed trial chunks used for offline retrieval fallback.
+TRIALS_DATA_PATH=.data/processed/trials.jsonl
+
+# --- Optional seeding helpers ---
+# Image and wait period used by scripts/seed_smallset.sh when auto-starting Qdrant.
+QDRANT_IMAGE=qdrant/qdrant
+QDRANT_WAIT_SECONDS=30

--- a/config/appsettings.example.toml
+++ b/config/appsettings.example.toml
@@ -1,42 +1,32 @@
+# Example application defaults for TrialWhisperer.
+#
+# Copy to config/appsettings.toml to provide non-secret fallback values that
+# complement the environment variables defined in config/.env. Secrets such as
+# API keys and managed service URLs should live in the environment.
+
 [server]
 host = "0.0.0.0"
 port = 8000
 
-
 [llm]
-provider = "gemini" # or "openai"
+provider = "gemini"
 model = "gemini-2.5-flash"
-api_key = "YOUR_GEMINI_API_KEY" # or set via LLM_API_KEY env var
-
 
 [retrieval]
-backend = "qdrant" # or "vertex"
-qdrant_url = "https://YOUR-QDRANT-URL" # or set via QDRANT_URL env var
-qdrant_api_key = "YOUR_QDRANT_KEY" # or set via QDRANT_API_KEY env var
+backend = "qdrant"
 collection = "trialwhisperer"
-
+qdrant_url = "http://localhost:6333"
 
 [data]
 raw_dir = ".data/raw"
 proc_dir = ".data/processed"
 
-
 [data.api]
-# ClinicalTrials.gov API base URL (defaults to https://www.clinicaltrials.gov/api/v2).
-# Uncomment base_url to target an alternate host if the service moves again.
-# base_url = "https://www.clinicaltrials.gov/api/v2"
-backend = "requests" # HTTP client backend ("httpx" or "requests")
+backend = "requests"
 page_size = 100
 max_studies = 200
-# User-Agent defaults to TrialWhisperer/ingest (+https://trialwhisperer.ai/contact);
-# override it with your own organization/contact string to represent your traffic.
-user_agent = "my-app/1.0 (admin@example.com)"
-
+user_agent = "TrialWhisperer/ingest (+https://trialwhisperer.ai/contact)"
 
 [data.api.params]
 "query.term" = "glioblastoma"
 "filter.overallStatus" = ["RECRUITING", "ACTIVE_NOT_RECRUITING"]
-
-
-[data.api.headers]
-"X-Contact" = "admin@example.com"


### PR DESCRIPTION
## Summary
- add a tracked config/.env.example template for common environment variables and allow config/.env to be committed
- point settings loading at config/.env, update README guidance, and refresh Docker instructions to rely on env files
- trim config/appsettings.example.toml to non-secret defaults that act as optional fallbacks

## Testing
- pytest app/test/test_deps_settings.py

------
https://chatgpt.com/codex/tasks/task_e_68daf234e63883258c4d37b88c71e8c7